### PR TITLE
Resolviendo issue #383

### DIFF
--- a/pyarweb/settings.py
+++ b/pyarweb/settings.py
@@ -231,6 +231,7 @@ RAVEN_CONFIG = None
 #
 #  Email confirmation app settings
 #
+EMAIL_CONFIRM_LA_DOMAIN="python.org.ar"
 EMAIL_CONFIRM_LA_CONFIRM_EXPIRE_SEC = 3600*24*7  # 7 días
 EMAIL_CONFIRM_LA_TEMPLATE_CONTEXT = {
     'confirmation_url_validity_time': EMAIL_CONFIRM_LA_CONFIRM_EXPIRE_SEC / (


### PR DESCRIPTION
Agregue el EMAIL_CONFIRMATION_LA_DOMAIN con el valor "python.org.ar". Probado en un servidor debug funciona correctamente el link en el email de confirmacion de inscripcion a eventos.